### PR TITLE
update gradient definition

### DIFF
--- a/svg-sparkline.js
+++ b/svg-sparkline.js
@@ -123,8 +123,8 @@ class SVGSparkline extends HTMLElement {
       content.push(`
         <defs>
           <linearGradient id="svg-sparkline-gradient-${gradientID}" gradientTransform="rotate(90)">
-            <stop offset="0%" stop-color="${gradientColor}" />
-            <stop offset="100%" stop-color="transparent" />
+            <stop offset="0%" stop-color="${gradientColor}" stop-opacity="1" />
+            <stop offset="100%" stop-color="${gradientColor}" stop-opacity="0" />
           </linearGradient>
         </defs>
       `)


### PR DESCRIPTION
In SVG 'transparent' is 'transparent black', and this means the linear gradient color disappears with a dark undertone. 

Source: https://svgwg.org/svg2-draft/pservers.html#StopColorProperties

You may want this, but if not you can transition the color between the fully opaque and fully transparent versions with the `stop-opacity` attribute.

```html
<stop offset="0%" stop-color="${gradientColor}" stop-opacity="1" />
<stop offset="100%" stop-color="${gradientColor}" stop-opacity="0" />
```

(for the first `stop` element the attribute is technically superfluous)
